### PR TITLE
update include directives

### DIFF
--- a/src/libfauxdqt/fileopener.cc
+++ b/src/libfauxdqt/fileopener.cc
@@ -21,10 +21,9 @@
 #include <QPointer>
 #include <QRegularExpression>
 
-#include <libaudcore/audstrings.h>
 #include <libfauxdcore/drct.h>
 #include <libfauxdcore/i18n.h>
-#include <libaudcore/interface.h>
+#include <libfauxdcore/interface.h>
 #include <libfauxdcore/playlist.h>
 #include <libfauxdcore/runtime.h>
 #include <libfauxdcore/audstrings.h>


### PR DESCRIPTION
Hi,
Build failed on my (Debian sid) system without one of the changes:

Compiling infopopup-qt.cc (lib)...
fileopener.cc:24:10: fatal error: libaudcore/audstrings.h: No such file or directory
   24 | #include <libaudcore/audstrings.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Failed to compile fileopener.cc (lib)!
make[6]: *** [../../buildsys.mk:418: fileopener.lib.o] Error 1
make[6]: *** Waiting for unfinished jobs....

The second is not yet tested.

Thanks!